### PR TITLE
Fix vulnerable version of Brace Expansion. Updated to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,8 +1773,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }


### PR DESCRIPTION
Updated Brace Expansion to 2.0.2 to address a low DoS vulnerability.

Details on: https://github.com/EverlyRusher/kaidev-landing-page/security/dependabot/1